### PR TITLE
update travis node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "8"
-  - "6"
+  - "lts/*"
+  - "node"
 script: "npm run build"


### PR DESCRIPTION
Noticed that the build was failing in Node v6: http://travis-ci.org/eBay/retriever/builds/406115085

Followed this from the Travis Docs:
https://docs.travis-ci.com/user/languages/javascript-with-nodejs/
> Specifying Node.js versions
The easiest way to specify Node.js versions is to use one or more of the latest releases in your .travis.yml:
node latest stable Node.js release
iojs latest stable io.js release
lts/* latest LTS Node.js release