### PR TITLE
implement cacheless lodash.get internally

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint *.js **/*.js",
-    "test": "istanbul cover _mocha test/index.js && node test/perf.js",
-    "build": "yarn run lint && yarn test",
+    "test": "istanbul cover _mocha test/index.js",
+    "perf": "node test/perf.js",
+    "build": "yarn run lint && yarn test && yarn perf",
     "rep": "open coverage/lcov-report/index.html",
     "all": "yarn run lint && yarn test && yarn run rep",
     "wrap": "rm -rf node_modules; rm yarn.lock; yarn cache clean && yarn"
@@ -21,9 +22,7 @@
   ],
   "author": "Yoni Medoff",
   "license": "MIT",
-  "dependencies": {
-    "lodash.get": "^4.4.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "chai": "^3.5.0",
     "chai-spies": "^0.7.1",

--- a/test/index.js
+++ b/test/index.js
@@ -24,6 +24,9 @@ var objectWithArrays = {
             {
                 c: 'test'
             }
+        ],
+        d: [
+            [1, 2, 3]
         ]
     }
 };
@@ -37,9 +40,17 @@ var emptyObjectWithPrototype = Object.create({prototypeProperty: 1});
             var value = r[accessor](basicObject, 'a.b.c', 1);
             expect(value).to.equal(0);
         });
-        it('accesses array elements', function () {
+        it('accesses array elements at end of path', function () {
+            var value = r[accessor](objectWithArrays, 'a.b[0]', {});
+            expect(value).to.equal(objectWithArrays.a.b[0]);
+        });
+        it('accesses array elements in middle of path', function () {
             var value = r[accessor](objectWithArrays, 'a.b[0].c');
             expect(value).to.equal(objectWithArrays.a.b[0].c);
+        });
+        it('accesses nested arrray elements', function () {
+            var value = r[accessor](objectWithArrays, 'a.d[0][1]', 1);
+            expect(value).to.equal(objectWithArrays.a.d[0][1]);
         });
         it('gets object value for basic object', function () {
             var value = r[accessor](basicObject, 'a.b', {});
@@ -52,6 +63,10 @@ var emptyObjectWithPrototype = Object.create({prototypeProperty: 1});
         it('uses default value when path doesn\'t exist', function () {
             var value = r[accessor](basicObject, 'a.b.d', 'default');
             expect(value).to.equal('default');
+        });
+        it('safely handles missing results in middle of path', function () {
+            var value = r[accessor](basicObject, 'a.asdf[1][2]', null);
+            expect(value).to.equal(null);
         });
         it('assumes default empty string when not passed in', function () {
             var value = r[accessor](basicObject, 'a.b.d');
@@ -73,7 +88,7 @@ var emptyObjectWithPrototype = Object.create({prototypeProperty: 1});
             var value = r[accessor](basicObject, 'a.b.d', emptyObjectWithPrototype);
             expect(value).to.deep.equal(defaultEmptyObject);
         });
-        it('defaults to defaultValue when result is undefined', function () {
+        it('defaults to defaultResult when result is undefined', function () {
             var value = r[accessor](basicObject, 'a.b.e', 'default');
             expect(value).to.deep.equal('default');
         });

--- a/test/perf.js
+++ b/test/perf.js
@@ -49,7 +49,7 @@ function buildObject(breadth, depth, type) {
     return obj;
 }
 
-function retrieverLoop(accessor, breadth, depth, calls, obj, paths, defaultValue, useWrongPath) {
+function retrieverLoop(accessor, breadth, depth, calls, obj, paths, defaultResult, useWrongPath) {
     var callsDone = 0;
     // keep repeating the breadth loop as necessary
     while (callsDone < calls) {
@@ -62,7 +62,7 @@ function retrieverLoop(accessor, breadth, depth, calls, obj, paths, defaultValue
                 if (useWrongPath) {
                     path += 'asdf'; // e.g. look for .stringasdf instead of .string
                 }
-                r[accessor](obj, path, defaultValue);
+                r[accessor](obj, path, defaultResult);
 
                 // stop breadth loop early when we hit the calls number
                 if (++callsDone >= calls) {
@@ -85,7 +85,7 @@ types.forEach(function (type) {
     scenarios.push({
         name: 'access ' + type,
         type: type,
-        defaultValue: defaults[type],
+        defaultResult: defaults[type],
         useWrongPath: false
     });
 });
@@ -94,7 +94,7 @@ types.forEach(function (type) {
     scenarios.push({
         name: 'access ' + type + ' with wrong default',
         type: type,
-        defaultValue: null, // takes advantage of `null` being its own type in retriever
+        defaultResult: null, // takes advantage of `null` being its own type in retriever
         useWrongPath: false
     });
 });
@@ -103,7 +103,7 @@ types.forEach(function (type) {
     scenarios.push({
         name: 'access ' + type + ' with wrong path',
         type: type,
-        defaultValue: defaults[type],
+        defaultResult: defaults[type],
         useWrongPath: true
     });
 });
@@ -123,14 +123,14 @@ var objectVariations = [
             var breadth = objectVariation.breadth;
             var depth = objectVariation.depth;
             var type = scenario.type;
-            var defaultValue = scenario.defaultValue;
+            var defaultResult = scenario.defaultResult;
             var useWrongPath = scenario.useWrongPath;
             var label = 'calls:' + calls + ', breadth:' + breadth + ', depth:' + depth;
             var obj = buildObject(breadth, depth, type);
             var paths = buildPaths(breadth, depth, type);
 
             console.time(label);
-            retrieverLoop(accessor, breadth, depth, calls, obj, paths, defaultValue, useWrongPath);
+            retrieverLoop(accessor, breadth, depth, calls, obj, paths, defaultResult, useWrongPath);
             console.timeEnd(label);
         });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,10 +760,6 @@ lodash.create@3.1.1:
     lodash._basecreate "^3.0.0"
     lodash._isiterateecall "^3.0.0"
 
-lodash.get@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
-
 lodash.isarguments@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz#2f573d85c6a24289ff00663b491c1d338ff3458a"


### PR DESCRIPTION
## Description
- implement version of `lodash.get` internally, and importantly, without caching
- remove `lodash.get` dependency
- minor refactoring and renaming

## Context
@DylanPiercey did some initial investigation around `lodash.get`s cache actually doing more harm than good for certain cases. It seemed that the cache required additional garbage collection time, which increased CPU usage across the board. In this PR, I've taken his initial code and made a few adjustments.

We will need to rerun the GC/CPU analysis. I'm putting the code here so it's easier to do that. We now also have #12, which we could potentially use for comparison.

Perf data:

Before:
```
### need() ###

access string
calls:5000, breadth:500, depth:25: 49.728ms
calls:5000, breadth:200, depth:10: 22.277ms
calls:5000, breadth:10, depth:5: 10.672ms

access array
calls:5000, breadth:500, depth:25: 36.228ms
calls:5000, breadth:200, depth:10: 5.139ms
calls:5000, breadth:10, depth:5: 2.562ms

access object
calls:5000, breadth:500, depth:25: 51.407ms
calls:5000, breadth:200, depth:10: 5.761ms
calls:5000, breadth:10, depth:5: 2.663ms

access string with wrong default
calls:5000, breadth:500, depth:25: 15.403ms
calls:5000, breadth:200, depth:10: 19.166ms
calls:5000, breadth:10, depth:5: 2.773ms

access array with wrong default
calls:5000, breadth:500, depth:25: 10.729ms
calls:5000, breadth:200, depth:10: 5.314ms
calls:5000, breadth:10, depth:5: 2.895ms

access object with wrong default
calls:5000, breadth:500, depth:25: 10.965ms
calls:5000, breadth:200, depth:10: 6.855ms
calls:5000, breadth:10, depth:5: 2.614ms

access string with wrong path
calls:5000, breadth:500, depth:25: 46.318ms
calls:5000, breadth:200, depth:10: 19.278ms
calls:5000, breadth:10, depth:5: 16.806ms

access array with wrong path
calls:5000, breadth:500, depth:25: 40.307ms
calls:5000, breadth:200, depth:10: 11.825ms
calls:5000, breadth:10, depth:5: 5.820ms

access object with wrong path
calls:5000, breadth:500, depth:25: 38.945ms
calls:5000, breadth:200, depth:10: 12.961ms
calls:5000, breadth:10, depth:5: 6.498ms


### get() ###

access string
calls:5000, breadth:500, depth:25: 11.766ms
calls:5000, breadth:200, depth:10: 8.993ms
calls:5000, breadth:10, depth:5: 2.671ms

access array
calls:5000, breadth:500, depth:25: 10.150ms
calls:5000, breadth:200, depth:10: 5.865ms
calls:5000, breadth:10, depth:5: 2.592ms

access object
calls:5000, breadth:500, depth:25: 11.270ms
calls:5000, breadth:200, depth:10: 6.605ms
calls:5000, breadth:10, depth:5: 4.495ms

access string with wrong default
calls:5000, breadth:500, depth:25: 11.732ms
calls:5000, breadth:200, depth:10: 8.324ms
calls:5000, breadth:10, depth:5: 2.746ms

access array with wrong default
calls:5000, breadth:500, depth:25: 10.266ms
calls:5000, breadth:200, depth:10: 5.784ms
calls:5000, breadth:10, depth:5: 2.619ms

access object with wrong default
calls:5000, breadth:500, depth:25: 11.900ms
calls:5000, breadth:200, depth:10: 5.964ms
calls:5000, breadth:10, depth:5: 2.667ms

access string with wrong path
calls:5000, breadth:500, depth:25: 12.989ms
calls:5000, breadth:200, depth:10: 11.507ms
calls:5000, breadth:10, depth:5: 6.339ms

access array with wrong path
calls:5000, breadth:500, depth:25: 13.481ms
calls:5000, breadth:200, depth:10: 12.912ms
calls:5000, breadth:10, depth:5: 5.984ms

access object with wrong path
calls:5000, breadth:500, depth:25: 13.769ms
calls:5000, breadth:200, depth:10: 12.975ms
calls:5000, breadth:10, depth:5: 6.064ms
```

After:
```
### need() ###

access string
calls:5000, breadth:500, depth:25: 19.270ms
calls:5000, breadth:200, depth:10: 15.027ms
calls:5000, breadth:10, depth:5: 7.294ms

access array
calls:5000, breadth:500, depth:25: 13.328ms
calls:5000, breadth:200, depth:10: 8.136ms
calls:5000, breadth:10, depth:5: 3.124ms

access object
calls:5000, breadth:500, depth:25: 10.418ms
calls:5000, breadth:200, depth:10: 5.380ms
calls:5000, breadth:10, depth:5: 3.131ms

access string with wrong default
calls:5000, breadth:500, depth:25: 15.182ms
calls:5000, breadth:200, depth:10: 10.502ms
calls:5000, breadth:10, depth:5: 7.763ms

access array with wrong default
calls:5000, breadth:500, depth:25: 12.230ms
calls:5000, breadth:200, depth:10: 5.270ms
calls:5000, breadth:10, depth:5: 3.126ms

access object with wrong default
calls:5000, breadth:500, depth:25: 13.192ms
calls:5000, breadth:200, depth:10: 6.321ms
calls:5000, breadth:10, depth:5: 3.789ms

access string with wrong path
calls:5000, breadth:500, depth:25: 15.563ms
calls:5000, breadth:200, depth:10: 18.917ms
calls:5000, breadth:10, depth:5: 5.856ms

access array with wrong path
calls:5000, breadth:500, depth:25: 10.714ms
calls:5000, breadth:200, depth:10: 8.062ms
calls:5000, breadth:10, depth:5: 3.774ms

access object with wrong path
calls:5000, breadth:500, depth:25: 10.419ms
calls:5000, breadth:200, depth:10: 8.403ms
calls:5000, breadth:10, depth:5: 3.799ms


### get() ###

access string
calls:5000, breadth:500, depth:25: 18.463ms
calls:5000, breadth:200, depth:10: 9.778ms
calls:5000, breadth:10, depth:5: 5.995ms

access array
calls:5000, breadth:500, depth:25: 10.492ms
calls:5000, breadth:200, depth:10: 5.830ms
calls:5000, breadth:10, depth:5: 3.462ms

access object
calls:5000, breadth:500, depth:25: 13.495ms
calls:5000, breadth:200, depth:10: 7.194ms
calls:5000, breadth:10, depth:5: 4.009ms

access string with wrong default
calls:5000, breadth:500, depth:25: 10.832ms
calls:5000, breadth:200, depth:10: 7.971ms
calls:5000, breadth:10, depth:5: 3.786ms

access array with wrong default
calls:5000, breadth:500, depth:25: 14.533ms
calls:5000, breadth:200, depth:10: 8.137ms
calls:5000, breadth:10, depth:5: 4.087ms

access object with wrong default
calls:5000, breadth:500, depth:25: 19.196ms
calls:5000, breadth:200, depth:10: 8.625ms
calls:5000, breadth:10, depth:5: 4.863ms

access string with wrong path
calls:5000, breadth:500, depth:25: 15.079ms
calls:5000, breadth:200, depth:10: 8.646ms
calls:5000, breadth:10, depth:5: 5.844ms

access array with wrong path
calls:5000, breadth:500, depth:25: 16.023ms
calls:5000, breadth:200, depth:10: 7.213ms
calls:5000, breadth:10, depth:5: 4.360ms

access object with wrong path
calls:5000, breadth:500, depth:25: 12.368ms
calls:5000, breadth:200, depth:10: 7.572ms
calls:5000, breadth:10, depth:5: 4.590ms
```